### PR TITLE
Fix auth password validation mismatch

### DIFF
--- a/WebServer/routes/auth.js
+++ b/WebServer/routes/auth.js
@@ -13,7 +13,8 @@ router.post(
     [
         body('username', 'Username is required').notEmpty().trim().escape(),
         body('email', 'Please include a valid email').isEmail().normalizeEmail(),
-        body('password', 'Password must be at least 6 characters long').isLength({ min: 8 }),
+        // Enforce the same minimum length as the client-side validation
+        body('password', 'Password must be at least 6 characters long').isLength({ min: 6 }),
     ],
     (req, res) => {
         // Check for validation errors


### PR DESCRIPTION
## Summary
- fix API validation mismatch for password length

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68434ccdf0f8832e93781fb4df070f22